### PR TITLE
fix tiled layout

### DIFF
--- a/itermocil.py
+++ b/itermocil.py
@@ -233,7 +233,7 @@ class Itermocil(object):
         elif layout == 'tiled':
 
             vertical_splits = int(ceil((num_panes / 2.0))) - 1
-            second_columns = num_panes / 2
+            second_columns = num_panes // 2
 
             for p in range(0, vertical_splits):
                 pp = (p * 2) + 1


### PR DESCRIPTION
When use tiled layout, it will cause an error:
TypeError: 'float' object cannot be interpreted as an integer